### PR TITLE
Added support for creating CloudWatch Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ npm install serverless-plugin-alerting
  - array of alerting definition objects (previous version: single alerting definition object still works)
  - you can add multiple alerts as an array of alerting-objects
  - you can add multiple mertic filters as in array of metricfilter-objects
+ - you can add multiple subscription filters as in array of subscritionfilter-objects
  - use-case:
     - alert1: submit normal notifications immediately to instant messenger (Example: Threshold: Errors >= 1 for 1 minute)
     - alert2: submit notification to statuspage of your service to notify the customers about a problem (Example: Threshold: Duration >= 500 for 5 minutes)
@@ -57,11 +58,13 @@ npm install serverless-plugin-alerting
     {
         "notificationTopicStageMapping": { ... },
         "metricFilters":  { ... },
+        "subscriptionFilters": { ... },
         "alerts": { ... }
     },
     {
         "notificationTopicStageMapping": { ... },
         "metricFilters":  { ... },
+        "subscriptionFilters": { ... },
         "alerts": { ... }
     }
 ]
@@ -83,6 +86,11 @@ npm install serverless-plugin-alerting
  - key: name of the metric filter that needs to be created
  - the values were used to fill up a aws-cli command
  - http://docs.aws.amazon.com/cli/latest/reference/logs/put-metric-filter.html
+
+#### Subscription Filters
+ - key: name of the subscription filter that needs to be created
+ - the values were used to fill up a aws-cli command
+ - http://docs.aws.amazon.com/cli/latest/reference/logs/put-subscription-filter.html
 
 #### Alerts
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ npm install serverless-plugin-alerting
 #### Structure
  - array of alerting definition objects (previous version: single alerting definition object still works)
  - you can add multiple alerts as an array of alerting-objects
+ - you can add multiple mertic filters as in array of metricfilter-objects
  - use-case:
     - alert1: submit normal notifications immediately to instant messenger (Example: Threshold: Errors >= 1 for 1 minute)
     - alert2: submit notification to statuspage of your service to notify the customers about a problem (Example: Threshold: Duration >= 500 for 5 minutes)
@@ -55,10 +56,12 @@ npm install serverless-plugin-alerting
 [
     {
         "notificationTopicStageMapping": { ... },
+        "metricFilters":  { ... },
         "alerts": { ... }
     },
     {
         "notificationTopicStageMapping": { ... },
+        "metricFilters":  { ... },
         "alerts": { ... }
     }
 ]
@@ -75,6 +78,11 @@ npm install serverless-plugin-alerting
     - If you want to react on these alarms you can subscribe Lambda-Functions to these Topics
     (For example Push a notification to a messaging system like slack, send a email or push data to any Rest-Api.)
     - @see https://github.com/martinlindenberg/serverless-plugin-sns :)
+
+#### Metric Filters
+ - key: name of the metric filter that needs to be created
+ - the values were used to fill up a aws-cli command
+ - http://docs.aws.amazon.com/cli/latest/reference/logs/put-metric-filter.html
 
 #### Alerts
 

--- a/alerting.json
+++ b/alerting.json
@@ -6,6 +6,18 @@
             "staging": "your-staging-sns-topic",
             "live": "your-live-sns-topic"
         },
+        "metricFilters": {
+            "usedMemory": {
+                "filterPattern": "[line_type=\"REPORT\",request_id_label,request_id,duration_label,duration,duration_ms,billed_duration_label1,billed_duration_label2,billed_duration,billed_duration_ms,allocated_memory_label1,allocated_memory_label2,allocated_memory,allocated_memory_mb,u
+sed_memory_label1,used_memory_label2,used_memory_label3,used_memory,used_memory_mb]",
+                "metricTransformations": [
+                    {
+                        "metricName": "usedMemory",
+                        "metricValue": "$used_memory"
+                    }
+                ]
+            }
+        },
         "alerts": {
             "Duration": {
                 "enabled": true,

--- a/alerting.json
+++ b/alerting.json
@@ -18,6 +18,14 @@ sed_memory_label1,used_memory_label2,used_memory_label3,used_memory,used_memory_
                 ]
             }
         },
+        "subscriptionFilters": {
+            "example": {
+                "filterName": "myexamplefilter",
+                "filterPattern": "",
+                "destinationArn": "arn:aws:logs:us-east-1:01234567890:destination:foo",
+                "roleArn": null
+            }
+        },
         "alerts": {
             "Duration": {
                 "enabled": true,

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = function(S) {
                 action: 'functionDeploy',
                 event:  'post'
             });
+
             S.addHook(this._addAlertsAfterDeploy.bind(this), {
                 action: 'dashDeploy',
                 event:  'post'
@@ -82,11 +83,17 @@ module.exports = function(S) {
                 let _this = this;
 
                 var metricFilterPromises = _this._createMetricFilters(functionAlertSettings, _this)
+                var subscriptionFilterPromises = _this._createSubscriptionFilters(functionAlertSettings, _this);
                 var alertPromises = _this._createAlerts(functionAlertSettings, _this);
 
                 BbPromise.all(metricFilterPromises)
                 .then(function(){
                     console.log('metric filters created');
+                });
+
+                BbPromise.all(subscriptionFilterPromises)
+                .then(function(){
+                    console.log('subscription filters created');
                 });
 
                 BbPromise.all(alertPromises)
@@ -184,6 +191,40 @@ module.exports = function(S) {
                 }
             }
             return metricFilterActions;
+        }
+
+        /**
+         * creates subscription filters for the function
+         *
+         * @param array functionAlertSettings List of settings for each deployed function
+         * @param object _this as this function returns an array, i can not use _createsubscriptionFilters(a,b).bind(_this) to attach a pointer to _this
+         *
+         * @return array
+         */
+        _createSubscriptionFilters (functionAlertSettings, _this) {
+            var subscriptionFilterActions = [];
+
+            for (var i in functionAlertSettings) {
+                var alertContents = functionAlertSettings[i];
+                for (var j in alertContents) {
+                    var alertContent = alertContents[j];
+                    if (!alertContent.metricFilters) {
+                        console.log('no subscription filters defined');
+                        return [];
+                    }
+                    var functionName = _this._getFunctionNameByArn(alertContent.Arn, _this.stage);
+                    var logGroupName = '/aws/lambda/' + functionName;
+
+                    for (var subscriptionFilter in alertContent.subscriptionFilters) {
+                        alertContent.subscriptionFilters[subscriptionFilter].filterName = subscriptionFilter;
+                        alertContent.subscriptionFilters[subscriptionFilter].logGroupName = logGroupName;
+                        subscriptionFilterActions.push(
+                                _this.cloudWatchLogs.putSubscriptionFilterAsync(alertContent.subscriptionFilters[subscriptionFilter])
+                        );
+                    }
+                }
+            }
+            return subscriptionFilterActions;
         }
 
         /**

--- a/index.js
+++ b/index.js
@@ -81,12 +81,19 @@ module.exports = function(S) {
                 // topics exist now
                 let _this = this;
 
+                var metricFilterPromises = _this._createMetricFilters(functionAlertSettings, _this)
                 var alertPromises = _this._createAlerts(functionAlertSettings, _this);
+
+                BbPromise.all(metricFilterPromises)
+                .then(function(){
+                    console.log('metric filters created');
+                });
 
                 BbPromise.all(alertPromises)
                 .then(function(){
                     console.log('alerts created');
                 });
+
             }.bind(_this))
             .catch(function(e){
                 SCli.log('error in creating alerts', e)
@@ -137,6 +144,46 @@ module.exports = function(S) {
             }
 
             return alertActions;
+        }
+
+        /**
+         * creates metric filters for the function
+         *
+         * @param array functionAlertSettings List of settings for each deployed function
+         * @param object _this as this function returns an array, i can not use _createMetricFilters(a,b).bind(_this) to attach a pointer to _this
+         *
+         * @return array
+         */
+        _createMetricFilters (functionAlertSettings, _this) {
+
+            var metricFilterActions = [];
+
+            for (var i in functionAlertSettings) {
+                var alertContents = functionAlertSettings[i];
+                for (var j in alertContents) {
+                    var alertContent = alertContents[j];
+                    if (!alertContent.metricFilters) {
+                        console.log('no metric filters defined');
+                        return [];
+                    }
+                    var functionName = _this._getFunctionNameByArn(alertContent.Arn, _this.stage);
+                    var logGroupName = '/aws/lambda/' + functionName;
+
+                    for (var metricfilter in alertContent.metricFilters) {
+                        alertContent.metricFilters[metricfilter].filterName = logGroupName + '_' + metricfilter;
+                        alertContent.metricFilters[metricfilter].logGroupName = logGroupName;
+                        alertContent.metricFilters[metricfilter].metricTransformations.forEach(function (transformation, index) {
+                            if(!transformation.metricNamespace) {
+                                transformation.metricNamespace = functionName;
+                            }
+                        });
+                        metricFilterActions.push(
+                                _this.cloudWatchLogs.putMetricFilterAsync(alertContent.metricFilters[metricfilter])
+                        );
+                    }
+                }
+            }
+            return metricFilterActions;
         }
 
         /**
@@ -200,6 +247,13 @@ module.exports = function(S) {
                 sessionToken: credentials.sessionToken
             });
 
+            _this.cloudWatchLogs = new AWS.CloudWatchLogs({
+                region: region,
+                accessKeyId: credentials.accessKeyId,
+                secretAccessKey: credentials.secretAccessKey,
+                sessionToken: credentials.sessionToken
+            });
+
             _this.sns = new AWS.SNS({
                 region: region,
                 accessKeyId: credentials.accessKeyId,
@@ -208,6 +262,7 @@ module.exports = function(S) {
             });
 
             BbPromise.promisifyAll(_this.cloudWatch);
+            BbPromise.promisifyAll(_this.cloudWatchLogs);
             BbPromise.promisifyAll(_this.sns);
         }
 


### PR DESCRIPTION
CloudWatch Logs MetricFilters allow you to find values in your logs and
turn them into CloudWatch metrics. You can then configure alarms on
these new metrics.
