### PR TITLE
Issue with SubscriptionFilters checking wrong key

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ module.exports = function(S) {
                 var alertContents = functionAlertSettings[i];
                 for (var j in alertContents) {
                     var alertContent = alertContents[j];
-                    if (!alertContent.metricFilters) {
+                    if (!alertContent.subscriptionFilters) {
                         console.log('no subscription filters defined');
                         return [];
                     }


### PR DESCRIPTION
The Subscription Filters code was checking for metricFilters key in the
alerting.json file instead of the subscriptionFilters key
