### PR TITLE
Fixed an enabled attribute bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -493,7 +493,7 @@ module.exports = function(S) {
             }
             var config = {
                 AlarmName: resourceName + ' ' + metric + ' -> ' + topicName,
-                ActionsEnabled: alertConfig.enabled || true,
+                ActionsEnabled: alertConfig.enabled == true ? true : false,
                 ComparisonOperator: alertConfig.comparisonOperator,
                 EvaluationPeriods: alertConfig.evaluationPeriod,
                 MetricName: metricName,


### PR DESCRIPTION
The enabled attribute in global-alerting.json is always true even if you specify false for it.

The problem code is:

```
$ node
> var alertConfig = { enabled: false };
undefined
> alertConfig
{ enabled: false }
> var config = { ActionsEnabled: alertConfig.enabled || true };
undefined
> config
{ ActionsEnabled: true }
```

The correct code is:

```
$ node
> var alertConfig = {enabled: false};
undefined
> alertConfig
{ enabled: false }
> var config = { ActionsEnabled: alertConfig.enabled == true ? true : false };
undefined
> config
{ ActionsEnabled: false }
```
